### PR TITLE
Feat: support different badge tiers/versions

### DIFF
--- a/src/main/java/de/kesuaheli/twitchchatbridge/badge/Badge.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/badge/Badge.java
@@ -1,7 +1,6 @@
 package de.kesuaheli.twitchchatbridge.badge;
 
 import com.github.twitch4j.helix.domain.ChatBadge;
-import com.github.twitch4j.helix.domain.ChatBadgeSet;
 import com.github.twitch4j.helix.domain.User;
 import com.mojang.blaze3d.platform.NativeImage;
 import de.kesuaheli.twitchchatbridge.TwitchChatMod;
@@ -30,6 +29,7 @@ import java.util.regex.Pattern;
 
 public class Badge {
     private final String name;
+    private final String version;
     private MutableComponent displayName;
     private Component description;
     Map<String, ChannelOverride> channelOverrides = new HashMap<>();
@@ -40,23 +40,24 @@ public class Badge {
     /**
      * An empty badge with a name set to "" and null image.
      */
-    public static final Badge EMPTY = new Badge("", null);
+    public static final Badge EMPTY = new Badge("", "", null);
 
-    Badge(String name, NativeImage image) {
+    Badge(String name, String version, NativeImage image) {
         this.name = name;
+        this.version = version;
         this.image = image;
     }
 
-    public Badge(ChatBadgeSet chatBadgeSet) throws IOException, URISyntaxException {
-        this.name = chatBadgeSet.getSetId();
-        ChatBadge lastVersion = chatBadgeSet.getVersions().getLast();
-        this.displayName = Component.literal(lastVersion.getTitle());
-        setDescription(lastVersion.getDescription());
+    public Badge(String name, ChatBadge badgeVersion) throws IOException, URISyntaxException {
+        this.name = name;
+        this.version = badgeVersion.getId();
+        this.displayName = Component.literal(badgeVersion.getTitle());
+        setDescription(badgeVersion.getDescription());
 
         String[] tryURLs = {
-            lastVersion.getLargeImageUrl(),
-            lastVersion.getMediumImageUrl(),
-            lastVersion.getSmallImageUrl(),
+            badgeVersion.getLargeImageUrl(),
+            badgeVersion.getMediumImageUrl(),
+            badgeVersion.getSmallImageUrl(),
         };
         for (int i = 0; i < tryURLs.length; i++) {
             if (i != 0) {
@@ -82,6 +83,7 @@ public class Badge {
 
     public Badge(User user) throws IOException, URISyntaxException {
         this.name = "@"+user.getLogin();
+        this.version = "";
         this.displayName = Component.literal(user.getDisplayName());
         setDescription(user.getDescription());
 
@@ -106,6 +108,7 @@ public class Badge {
      */
     Badge(Badge badge) {
         this.name = badge.name;
+        this.version = badge.name;
         this.displayName = badge.displayName;
         this.description = badge.description;
         this.channelOverrides = badge.channelOverrides;
@@ -119,6 +122,13 @@ public class Badge {
      */
     public String getName() {
         return name;
+    }
+
+    /**
+     * @return The version of the badge
+     */
+    public String getVersion() {
+        return version;
     }
 
     /**
@@ -328,7 +338,7 @@ public class Badge {
             }
 
             String name = matcher.group("badgeName");
-            Badge badge = new Badge(name, null);
+            Badge badge = new Badge(name, "", null);
             badge.resourcePackOverrideImage = image;
             if (channelID == null) {
                 TwitchChatMod.BADGES.add(badge);

--- a/src/main/java/de/kesuaheli/twitchchatbridge/badge/Badge.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/badge/Badge.java
@@ -313,11 +313,19 @@ public class Badge {
 
         final String regex = startingPath + "/(?:global|channel/(?<channelName>[a-z0-1_]+))/(?<badgeName>[a-z0-1_]+)\\.png";
         final Pattern pattern = Pattern.compile(regex);
-        resources.forEach((identifier, resource) -> {
+        for (Identifier identifier : resources.keySet()) {
             if (!identifier.getNamespace().equals(BadgeFont.IDENTIFIER.getNamespace())) return;
             Matcher matcher = pattern.matcher(identifier.getPath());
             if (!matcher.matches()) return;
 
+            // TODO: implement new RP support for badges
+            TwitchChatMod.LOGGER.error("resource pack support is currently not working.");
+            TwitchChatMod.addNotification(Component.literal("")
+                .append(Component.literal("Twitch Chat Bridge Warning: ").withStyle(ChatFormatting.RED))
+                .append("You tried to load a resource pack with badge override textures, but these are currently not working due to recent structural changes for badges in version 0.20.0b!")
+            );
+            return;
+            /*
             String channelID = null;
             try {
                 String channelName = matcher.group("channelName");
@@ -332,7 +340,7 @@ public class Badge {
 
             NativeImage image;
             try {
-                image = NativeImage.read(resource.open());
+                image = NativeImage.read(resources.get(identifier).open());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -345,7 +353,8 @@ public class Badge {
             } else {
                 TwitchChatMod.BADGES.add(channelID, badge);
             }
-        });
+            */
+        }
     }
 
     public class ChannelOverride {

--- a/src/main/java/de/kesuaheli/twitchchatbridge/badge/BadgeSet.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/badge/BadgeSet.java
@@ -1,11 +1,16 @@
 package de.kesuaheli.twitchchatbridge.badge;
 
+import com.github.twitch4j.helix.domain.ChatBadgeSet;
+import de.kesuaheli.twitchchatbridge.TwitchChatMod;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class BadgeSet {
   private static final char MIN_CHAR = ' ' + 1;
@@ -35,14 +40,16 @@ public class BadgeSet {
 
   /**
    * Access the global badge for the given name. You may want to use
-   * {@link BadgeSet#get(String channelID, String name)} instead to also include the channel specific badges.
+   * {@link BadgeSet#get(String channelID, String name, String version)} instead to also include the channel specific
+   * badges.
    * @param name The name to search the badge for.
+   * @param version The version to search the badge for.
    * @return The badge for the name.
    * @throws IllegalArgumentException If the given name is not a global badge.
    */
-  public Badge get(String name) throws IllegalArgumentException {
+  public Badge get(String name, String version) throws IllegalArgumentException {
     return badges.values().stream()
-        .filter(badge -> badge.getName().equals(name))
+        .filter(badge -> badge.getName().equals(name) && badge.getVersion().equals(version))
         .findFirst()
         .orElseThrow(() -> new IllegalArgumentException("badge named '" + name + "' does not exist"));
   }
@@ -52,39 +59,44 @@ public class BadgeSet {
    * global badge.
    * @param channelID The channel ID to include in the search.
    * @param name The name to search the badge for.
+   * @param version The version to search the badge for.
    * @return The badge for the name.
    * @throws IllegalArgumentException If the given name is neither a channel badge nor a global badges.
    */
-  public Badge get(String channelID, String name) throws IllegalArgumentException {
-    Badge badge = get(name);
+  public Badge get(String channelID, String name, String version) throws IllegalArgumentException {
+    Badge badge = get(name, version);
     Badge.ChannelOverride override = badge.getChannelOverride(channelID);
     if (override == null) return badge;
     return override.toBadge();
   }
 
   /**
-   * Access the badge for the given name. Unlike {@link BadgeSet#get(String channelID, String name)} this method only
+   * Access the badge for the given name. Unlike {@link BadgeSet#get(String channelID, String name, String version)}
+   * this method only
    * searches for a channel badge but not a global badge.
    * @param channelID The channel ID of the badge.
    * @param name The name to search the badge for.
+   * @param version The version to search the badge for.
    * @return The badge for the name.
    * @throws IllegalArgumentException If the given name is neither a channel badge nor a global badges.
    */
-  public Badge getChannelOnly(String channelID, String name) {
-    Badge.ChannelOverride override = get(name).getChannelOverride(channelID);
+  public Badge getChannelOnly(String channelID, String name, String version) {
+    Badge.ChannelOverride override = get(name, version).getChannelOverride(channelID);
     if (override == null) throw new IllegalArgumentException("badge named '" + name + "' does not exist for channel '" + channelID + "'");
     return override.toBadge();
   }
 
   /**
    * Get the code point string for the given global badge name. You may want to use
-   * {@link BadgeSet#getChar(String channelID, String name)} instead to also include the channel specific badges.
+   * {@link BadgeSet#getChar(String channelID, String name, String version)} instead to also include the channel
+   * specific badges.
    * @param name The name to search the badge for.
+   * @param version The version to search the badge for.
    * @return The code point string to use this badge in a text.
    * @throws IllegalArgumentException If the given name is not a global badge.
    */
-  public String getChar(String name) throws IllegalArgumentException {
-    return get(name).getChar();
+  public String getChar(String name, String version) throws IllegalArgumentException {
+    return get(name, version).getChar();
   }
 
   /**
@@ -92,17 +104,48 @@ public class BadgeSet {
    * search for the global badge.
    * @param channelID The channel ID to include in the search.
    * @param name The name to search the badge for.
+   * @param version The version to search the badge for.
    * @return The code point string to use this badge in a text.
    * @throws IllegalArgumentException If the given name is neither a channel badge nor a global badge.
    */
-  public String getChar(String channelID, String name) throws IllegalArgumentException {
-    return get(channelID, name).getChar();
+  public String getChar(String channelID, String name, String version) throws IllegalArgumentException {
+    return get(channelID, name, version).getChar();
   }
 
   public void clearResourcePackOverrides() {
     badges.values().stream()
         .filter(Badge::hasResourcePackOverride)
         .forEach(Badge::unsetResourcePackOverride);
+  }
+
+  /**
+   * Adds multiple new global chat badges. Use {@link BadgeSet#add(String channelID, ChatBadgeSet chatBadgeSet)} to add
+   * channel specific badges instead. All badge versions in the given chatBadgeSet will be added.
+   * @param chatBadgeSet The set to extract the name and versions from.
+   */
+  public void add(ChatBadgeSet chatBadgeSet) {
+    add(null, chatBadgeSet);
+  }
+
+  /**
+   * Adds multiple new channel specific chat badges. User {@link BadgeSet#add(ChatBadgeSet chatBadgeSet)} to add global
+   * badges instead. All badge versions in the given chatBadgeSet will be added.
+   * @param channelID The channel ID to add the badges to.
+   * @param chatBadgeSet The set to extract the name and versions from.
+   */
+  public void add(String channelID, ChatBadgeSet chatBadgeSet) {
+    chatBadgeSet.getVersions().forEach(badgeVersion -> {
+      final Badge badge;
+      try {
+        badge = new Badge(chatBadgeSet.getSetId(), badgeVersion);
+      } catch (URISyntaxException | IOException e) {
+        String badgeType = channelID == null ? "global " : "";
+        String channel = channelID == null ? "" : " for channel "+channelID;
+        TwitchChatMod.LOGGER.warn("Skipping to add {}badge '{}'{} on version '{}' because of failure", badgeType, chatBadgeSet.getSetId(), channel, badgeVersion.getId());
+        return;
+      }
+      add(channelID, badge);
+    });
   }
 
   /**
@@ -113,7 +156,7 @@ public class BadgeSet {
   public void add(@NotNull Badge badge) {
     Badge badgeBefore;
     try {
-      badgeBefore = get(badge.getName());
+      badgeBefore = get(badge.getName(), badge.getVersion());
     } catch (IllegalArgumentException ignored){
       put(badge);
       return;
@@ -133,7 +176,7 @@ public class BadgeSet {
     }
     Badge parentBadge;
     try {
-      parentBadge = get(badge.getName());
+      parentBadge = get(badge.getName(), badge.getVersion());
     } catch (IllegalArgumentException ignored) {
       parentBadge = new Badge(badge);
       add(badge);

--- a/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/Bot.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/Bot.java
@@ -212,7 +212,14 @@ public class Bot {
     if (this.pendingBadges == null ) return;
 
     this.userBadges = new ArrayList<>();
+    final boolean[] isFounder = {false};
     this.pendingBadges.forEach((name, version) -> {
+      if (isFounder[0] && name.equals("subscriber")) {
+        return;
+      } else if (name.equals("founder")) {
+        isFounder[0] = true;
+        this.userBadges.removeIf(b -> b.getName().equals("subscriber"));
+      }
       try {
         Badge badge = TwitchChatMod.BADGES.get(this.channelID, name, version);
         this.userBadges.add(badge);

--- a/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/Bot.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/Bot.java
@@ -15,8 +15,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -88,7 +86,7 @@ public class Bot {
     this.userBadges = new ArrayList<>();
     event.getMessageEvent().getBadges().forEach((name,  version) -> {
       try {
-        Badge badge = TwitchChatMod.BADGES.get(name);
+        Badge badge = TwitchChatMod.BADGES.get(name, version);
         this.userBadges.add(badge);
       } catch (IllegalArgumentException ignored) {}
     });
@@ -202,26 +200,8 @@ public class Bot {
       twitchClient.getChat().joinChannel(this.channel); // Join the new channel
 
       String channelID = getUserID(channel);
-      twitchClient.getHelix().getGlobalChatBadges(this.oauthKey).execute().getBadgeSets().forEach(chatBadgeSet -> {
-        final Badge badge;
-        try {
-          badge = new Badge(chatBadgeSet);
-        } catch (URISyntaxException | IOException e) {
-          TwitchChatMod.LOGGER.warn("Skipping to add badge {} because of failure", chatBadgeSet.getSetId());
-          return;
-        }
-        TwitchChatMod.BADGES.add(badge);
-      });
-      twitchClient.getHelix().getChannelChatBadges(this.oauthKey, channelID).execute().getBadgeSets().forEach(chatBadgeSet -> {
-        final Badge badge;
-        try {
-          badge = new Badge(chatBadgeSet);
-        } catch (URISyntaxException | IOException e) {
-          TwitchChatMod.LOGGER.warn("Skipping to add badge {} for channel {} because of failure", chatBadgeSet.getSetId(), channelID);
-          return;
-        }
-        TwitchChatMod.BADGES.add(channelID, badge);
-      });
+      twitchClient.getHelix().getGlobalChatBadges(this.oauthKey).execute().getBadgeSets().forEach(TwitchChatMod.BADGES::add);
+      twitchClient.getHelix().getChannelChatBadges(this.oauthKey, channelID).execute().getBadgeSets().forEach(chatBadgeSet -> TwitchChatMod.BADGES.add(channelID, chatBadgeSet));
       BadgeFont.reload();
 
       handlePendingBadges();
@@ -234,7 +214,7 @@ public class Bot {
     this.userBadges = new ArrayList<>();
     this.pendingBadges.forEach((name, version) -> {
       try {
-        Badge badge = TwitchChatMod.BADGES.get(this.channelID, name);
+        Badge badge = TwitchChatMod.BADGES.get(this.channelID, name, version);
         this.userBadges.add(badge);
       } catch (IllegalArgumentException ignored) {}
     });

--- a/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/FormatMessage.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/FormatMessage.java
@@ -49,7 +49,7 @@ public class FormatMessage {
     List<Badge> badges = new ArrayList<>();
     event.getMessageEvent().getBadges().forEach((name,  version) -> {
       try {
-        Badge badge = TwitchChatMod.BADGES.get(event.getChannel().getId(), name);
+        Badge badge = TwitchChatMod.BADGES.get(event.getChannel().getId(), name, version);
         badges.add(badge);
       } catch (IllegalArgumentException ignored) {}
     });
@@ -118,7 +118,7 @@ public class FormatMessage {
 
     Badge badge;
     try {
-      badge = TwitchChatMod.BADGES.get("@" + user.getLogin());
+      badge = TwitchChatMod.BADGES.get("@" + user.getLogin(), "");
     } catch (IllegalArgumentException e) {
       try {
         badge = new Badge(user);

--- a/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/FormatMessage.java
+++ b/src/main/java/de/kesuaheli/twitchchatbridge/twitch_integration/FormatMessage.java
@@ -47,7 +47,14 @@ public class FormatMessage {
     }
 
     List<Badge> badges = new ArrayList<>();
+    final boolean[] isFounder = {false};
     event.getMessageEvent().getBadges().forEach((name,  version) -> {
+      if (isFounder[0] && name.equals("subscriber")) {
+        return;
+      } else if (name.equals("founder")) {
+        isFounder[0] = true;
+        badges.removeIf(b -> b.getName().equals("subscriber"));
+      }
       try {
         Badge badge = TwitchChatMod.BADGES.get(event.getChannel().getId(), name, version);
         badges.add(badge);


### PR DESCRIPTION
Implement support for all the different versions a badge could have e.g. subscriber tiers, sub-gift tiers...

closes: #31

- [x] fetch and use badges
- [x] ~~support from ressource packs~~ moved into seperate issue: #37
- [x] exclude `subscriber`, if user has `founder` badge
- [x] fix: fetch user badges on connect